### PR TITLE
Include `source`s for ANP-specific repositories to support dev workflow.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "glocalcoop/activist-network",
+    "homepage": "http://glocal.coop/activist-network-platform/",
     "authors": [
         {
             "name": "Pea, Glocal",
@@ -10,6 +11,9 @@
             "email": "dana@glocal.coop"
         }
     ],
+    "support": {
+        "wiki": "https://plan.glocal.coop/projects/activitstnetwork/wiki"
+    },
     "repositories": [
         {
             "type": "composer",
@@ -24,6 +28,11 @@
                 "dist": {
                     "type": "zip",
                     "url": "https://github.com/glocalcoop/anp-global-menu/archive/master.zip"
+                },
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/glocalcoop/anp-global-menu.git",
+                    "reference": "master"
                 }
             }
         },
@@ -36,6 +45,11 @@
                 "dist": {
                     "type": "zip",
                     "url": "https://github.com/glocalcoop/anp-meetings/archive/master.zip"
+                },
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/glocalcoop/anp-meetings.git",
+                    "reference": "master"
                 }
             }
         },
@@ -48,6 +62,11 @@
                 "dist": {
                     "type": "zip",
                     "url": "https://github.com/glocalcoop/anp-network-content/archive/master.zip"
+                },
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/glocalcoop/anp-network-content.git",
+                    "reference": "master"
                 }
             }
         },
@@ -60,6 +79,11 @@
                 "dist": {
                     "type": "zip",
                     "url": "https://github.com/glocalcoop/anp-buddypress-customization/archive/master.zip"
+                },
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/glocalcoop/anp-buddypress-customization.git",
+                    "reference": "master"
                 }
             }
         },
@@ -72,6 +96,11 @@
                 "dist": {
                     "type": "zip",
                     "url": "https://github.com/glocalcoop/handbook/archive/master.zip"
+                },
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/glocalcoop/handbook.git",
+                    "reference": "master"
                 }
             }
         },
@@ -120,6 +149,11 @@
                 "dist": {
                     "type": "zip",
                     "url": "https://github.com/glocalcoop/anp-network-main-theme/archive/master.zip"
+                },
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/glocalcoop/anp-network-main-theme.git",
+                    "reference": "master"
                 }
             }
         },
@@ -132,6 +166,11 @@
                 "dist": {
                     "type": "zip",
                     "url": "https://github.com/glocalcoop/anp-network-subsite-theme/archive/master.zip"
+                },
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/glocalcoop/anp-network-subsite-theme.git",
+                    "reference": "master"
                 }
             }
         },
@@ -144,10 +183,15 @@
                 "dist": {
                     "type": "zip",
                     "url": "https://github.com/glocalcoop/anp-network-partner-theme/archive/master.zip"
+                },
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/glocalcoop/anp-network-partner-theme.git",
+                    "reference": "master"
                 }
             }
         },
-	{
+        {
             "type": "package",
             "package": {
                 "name": "TechToThePeople/civisualize",
@@ -278,7 +322,7 @@
         "wpackagist-plugin/members": ">=1.1.1",
         "wpackagist-plugin/moderate-new-blogs": ">=4.3",
         "wpackagist-plugin/more-privacy-options": ">=4.1.1",
-	"wpackagist-plugin/multisite-plugin-manager": "3.1.4",
+        "wpackagist-plugin/multisite-plugin-manager": "3.1.4",
         "wpackagist-plugin/nav-menu-roles": ">=1.7.7",
         "wpackagist-plugin/polylang": ">=1.8.3",
         "wpackagist-plugin/polylang-theme-strings": ">=2.2",
@@ -347,6 +391,9 @@
         "wpackagist-plugin/user-switching": ">=1.0.9",
         "wpackagist-plugin/wp-example-content": ">=1.3",
         "phpunit/phpunit": "4.8.*"
+    },
+    "suggest": {
+        "wpackagist-plugin/buoy": "Better Angels' Buoy is a community-based crisis response system compatible with the Activist Network Platform."
     },
     "extra": {
         "installer-paths": {


### PR DESCRIPTION
This commit adds explicit `source` repositories for projects that are
ANP-specific plugins or themes. This supports automating development
workflows by allowing `--prefer-source` to clone, rather than "install"
the project code, bringing VCS history along with the source itself.

Also, this commit:
- adds an explicit `support` key,
- notes the project homepage, and
- `suggest`s that [Buoy](https://wordpress.org/plugins/buoy) be added.
